### PR TITLE
Add support for receiving Set_Reports from the host

### DIFF
--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -130,13 +130,11 @@ bool HID_::setup(USBSetup& setup) {
       return true;
     }
     if (request == HID_SET_REPORT) {
-      //uint8_t reportID = setup.wValueL;
-      //uint16_t length = setup.wLength;
-      //uint8_t data[length];
-      // Make sure to not read more data than USB_EP_SIZE.
-      // You can read multiple times through a loop.
-      // The first byte (may!) contain the reportID on a multreport.
-      //USB_RecvControl(data, length);
+      uint16_t length = setup.wLength;
+
+      if (length == sizeof(setReportData)) {
+        USB_RecvControl(&setReportData, length);
+      }
     }
   }
 
@@ -146,6 +144,8 @@ bool HID_::setup(USBSetup& setup) {
 HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
   rootNode(NULL), descriptorSize(0),
   protocol(HID_REPORT_PROTOCOL), idle(1) {
+  setReportData.reportId = 0;
+  setReportData.leds = 0;
   epType[0] = EP_TYPE_INTERRUPT_IN;
   PluggableUSB().plug(this);
 }

--- a/src/HID.h
+++ b/src/HID.h
@@ -92,6 +92,7 @@ class HID_ : public PluggableUSBModule {
   int begin(void);
   int SendReport(uint8_t id, const void* data, int len);
   void AppendDescriptor(HIDSubDescriptor* node);
+  uint8_t getLEDs(void) { return setReportData.leds; };
 
  protected:
   // Implementation of the PluggableUSBModule
@@ -108,6 +109,10 @@ class HID_ : public PluggableUSBModule {
 
   uint8_t protocol;
   uint8_t idle;
+  struct {
+    uint8_t reportId;
+    uint8_t leds;
+  } setReportData;
 };
 
 // Replacement for global singleton.


### PR DESCRIPTION
This allows us to sync NumLock, CapsLock, ScrollLock, and similar LEDs with the host. Also adds a `.getLEDs` method to retrieve the state of the LEDs.