### PR TITLE
Add support for single-report devices receiving SET_REPORT

### DIFF
--- a/src/HID.cpp
+++ b/src/HID.cpp
@@ -134,6 +134,9 @@ bool HID_::setup(USBSetup& setup) {
 
       if (length == sizeof(setReportData)) {
         USB_RecvControl(&setReportData, length);
+      } else if (length == sizeof(setReportData.leds)) {
+        USB_RecvControl(&setReportData.leds, length);
+        setReportData.reportId = 0;
       }
     }
   }


### PR DESCRIPTION
When handling `HID_SET_REPORT`, if the size of the request is smaller than our `setReportData`, but is the same as the size of `setReportData.leds`, read it into the latter, and set `reportId` to zero.

This makes single-report devices support `HID_SET_REPORT` too.